### PR TITLE
Feature to select currently open windows when saving a new project

### DIFF
--- a/src/js/ProjectTabManager.js
+++ b/src/js/ProjectTabManager.js
@@ -155,6 +155,21 @@ var ProjectTabManager = (function() {
         });
       });
     },
+    // new method to add Project from selected tabs
+    addProjectSelected: function(name, tabs, callback) {
+        //getCurrentTabs(function(tabs) {
+        chrome.bookmarks.create({
+          parentId: projectsRootId,
+          title: name || 'Untitled'
+        }, function(newProject) {
+          for (var i = 0; i < tabs.length; i++) {
+            createBookmark(newProject.id, tabs[i]);
+          }
+          callback(newProject);
+          cache.renew();
+        });
+      //});
+    },
     getProject: cache.getProject.bind(cache),
     getProjectList: function(callback) {
       cache.renew(callback);

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -103,6 +103,16 @@ chrome.extension.onRequest.addListener(function(req, sender, callback) {
       callback(newProject);
     });
     break;
+  case 'addProjectSelected':
+    ProjectTabManager.addProjectSelected(req.name || 'New Project', req.tabs, function(newProject) {
+      chrome.windows.getCurrent(function(win) {
+        windowManager[win.id] = newProject;
+        windowHistory[win.id] = {};
+        windowHistory[win.id].title = newProject.title;
+      });
+      callback(newProject);
+    });
+    break;  
   case 'remove':
     ProjectTabManager.removeBookmark(req.bookmarkId, callback);
     break;

--- a/src/js/ng-controllers.js
+++ b/src/js/ng-controllers.js
@@ -21,6 +21,7 @@ app.controller('ProjectListCtrl', function($scope, Background) {
   $scope.currentWinId = '0';
   $scope.currentTabs = [];
   $scope.projectId = '0';
+  
 
   $scope.reload = function(projectId) {
     Background.projects(function(projects) {
@@ -67,6 +68,23 @@ app.controller('ProjectCtrl', function($scope, Background) {
     if ($scope.project_name.length === 0) return;
     Background.addProject($scope.project_name, $scope.currentWinId, function(project) {
       $scope.reload(project.id);
+    });
+  };
+
+  // new method to add Project from selected tabs
+  $scope.addSelected = function() {
+    if ($scope.project_name.length === 0) return;
+
+    $scope.checkedTabs=[];
+    //create array of checked tabs 
+    angular.forEach($scope.project.children, function(tab) {
+      if (tab.adding) {
+        $scope.checkedTabs.push(tab);
+      }
+    });
+
+    Background.addProjectSelected($scope.project_name, $scope.checkedTabs, function(project) {
+       $scope.reload(project.id);
     });
   };
 

--- a/src/js/ng-services.js
+++ b/src/js/ng-services.js
@@ -43,6 +43,10 @@ app.factory('Background', function() {
     addProject: function(name, winId, callback) {
       chrome.extension.sendRequest({command: 'addProject', name: name, winId: winId}, callback);
     },
+    // Create folder and add checked tabs in specified window there
+    addProjectSelected: function(name, bookmarks, callback) {
+      chrome.extension.sendRequest({command: 'addProjectSelected', name: name, tabs: bookmarks}, callback);
+    },
     // Remove specified bookmark from project
     remove: function(bookmarkId, callback) {
       chrome.extension.sendRequest({command: 'remove', bookmarkId: bookmarkId}, callback);

--- a/src/ng-popup.html
+++ b/src/ng-popup.html
@@ -57,9 +57,11 @@ Author: Eiji Kitamura (agektmr@gmail.com)
             </li>
             <li ng-show="project.id==0">
               <input type="text" ng-model="project_name" chrome-i18n="project_name:placeholder" />
-              <input type="button" ng-click="add()" chrome-i18n="save:value" />
+              <input type="button" ng-click="addSelected()" chrome-i18n="save:value" />
             </li>
-            <li ng-repeat="bookmark in project.children | normalize:projectId | filter:query" ng-controller="BookmarkCtrl" ng-init="hover=false" ng-mouseover="hover=true" ng-mouseleave="hover=false">
+	    <li ng-repeat="bookmark in project.children | normalize:projectId | filter:query" ng-controller="BookmarkCtrl" ng-init="hover=false" ng-mouseover="hover=true" ng-mouseleave="hover=false">
+	            <!--check boxes to select tabs-->
+              <input type="checkbox" ng-show="project.id==0" ng-model="bookmark.adding" />
               <img ng-src="http://www.google.com/s2/favicons?domain={{domain}}" class="favicon" />
               <span class="name" ng-class="{passive: passive, current: current, adding: adding}"><a href="{{bookmark.url}}" target="_blank" title="{{bookmark.title}}
 {{bookmark.url}}">{{bookmark.title}}</a></span>


### PR DESCRIPTION
Wouldn't it be handy, If you can **save some, not all  tabs from currently open tabs** when saving a new project? I have added check boxes to do so.
- check boxes are shown for new projects only
- by default all check boxes are selected ( means all selected tabs will be saved)
- deselect check box if you do not want to save tab  

I have kept old method as it is. So added method code is quite redundant to old method.
