### PR TITLE
Use material design list formatting for session and project lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 node_modules
 bower_components
 lib
+app

--- a/src/elements/ptm-project-list/ptm-project-list.html
+++ b/src/elements/ptm-project-list/ptm-project-list.html
@@ -25,6 +25,12 @@ Author: Eiji Kitamura (agektmr@gmail.com)
     *:focus {
       outline: none;
     }
+
+    /* Hide the topmost border and avoid double borders */
+    ptm-session[expanded]:first-of-type,
+    ptm-session[expanded] + ptm-session[expanded] {
+      border-top: none;
+    }
   </style>
   <template>
     <template id="repeat" is="dom-repeat" items="[[projects]]" filter="filter">

--- a/src/elements/ptm-project/ptm-project.html
+++ b/src/elements/ptm-project/ptm-project.html
@@ -19,7 +19,6 @@ Author: Eiji Kitamura (agektmr@gmail.com)
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../bower_components/paper-item/paper-item.html">
 <link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
-<link rel="import" href="../../bower_components/paper-material/paper-material.html">
 <link rel="import" href="../../bower_components/paper-ripple/paper-ripple.html">
 <link rel="import" href="../../bower_components/iron-collapse/iron-collapse.html">
 <link rel="import" href="../../bower_components/iron-selector/iron-selector.html">
@@ -37,8 +36,9 @@ Author: Eiji Kitamura (agektmr@gmail.com)
     :host:focus {
       outline: none;
     }
-    paper-material[expanded] {
-      margin: 0 0 1em 0;
+    :host([expanded]) {
+      border-top: 1px solid var(--divider-color);
+      border-bottom: 1px solid var(--divider-color);
     }
     paper-item > *:not(:first-child):not(:last-child) {
       margin-right: 0 !important;
@@ -64,39 +64,37 @@ Author: Eiji Kitamura (agektmr@gmail.com)
     }
   </style>
   <template>
-    <paper-material elevation="[[_elevation]]" expanded$="[[expanded]]" animated>
-      <paper-item focused$="{{focused}}" tabindex="-1">
-        <paper-icon-button tabindex="-1" icon="[[_foldIcon]]" on-tap="toggle"></paper-icon-button>
-        <div class="title" on-tap="openProject" active$="[[_isNotRemovable(projectId)]]">
-          <!-- <paper-ripple></paper-ripple> -->
-          <span>{{projectTitle}}</span>
-        </div>
-        <template is="dom-if" if="[[expanded]]">
-          <paper-icon-button icon="create" on-tap="_onTapRename" tabindex="-1"></paper-icon-button>
-          <template is="dom-if" if="[[!_isNotRemovable()]]">
-            <paper-icon-button icon="delete" on-tap="_onTapRemove" tabindex="-1"></paper-icon-button>
-          </template>
+    <paper-item expanded$="{{expanded}}" focused$="{{focused}}" tabindex="-1">
+      <paper-icon-button tabindex="-1" icon="[[_foldIcon]]" on-tap="toggle"></paper-icon-button>
+      <div class="title" on-tap="openProject" active$="[[_isNotRemovable(projectId)]]">
+        <!-- <paper-ripple></paper-ripple> -->
+        <span>{{projectTitle}}</span>
+      </div>
+      <template is="dom-if" if="[[expanded]]">
+        <paper-icon-button icon="create" on-tap="_onTapRename" tabindex="-1"></paper-icon-button>
+        <template is="dom-if" if="[[!_isNotRemovable()]]">
+          <paper-icon-button icon="delete" on-tap="_onTapRemove" tabindex="-1"></paper-icon-button>
         </template>
-      </paper-item>
-      <iron-collapse id="collapse" opened="[[expanded]]" tabindex="-1">
-        <template is="dom-if" if="[[!fields.length]]">
-          <paper-item class="layout">
-            <paper-icon-button icon="icons:warning"></paper-icon-button>
-            <span class="title">{{_l10n('no_bookmarks')}}</span>
-          </paper-item>
-        </template>
-        <template id="repeat" is="dom-repeat" items="[[fields]]">
-          <ptm-bookmark
-            url="[[item.url]]"
-            fav-icon-url="{{item.favIconUrl}}"
-            bookmark-id="[[item.id]]"
-            tab-id="[[item.tabId]]"
-            site-title="[[item.title]]"
-            project-id="[[projectId]]"
-            on-toggle-bookmark="_toggleBookmark"></ptm-bookmark>
-        </template>
-      </iron-collapse>
-    </paper-material>
+      </template>
+    </paper-item>
+    <iron-collapse id="collapse" opened="[[expanded]]" tabindex="-1">
+      <template is="dom-if" if="[[!fields.length]]">
+        <paper-item class="layout">
+          <paper-icon-button icon="icons:warning"></paper-icon-button>
+          <span class="title">{{_l10n('no_bookmarks')}}</span>
+        </paper-item>
+      </template>
+      <template id="repeat" is="dom-repeat" items="[[fields]]">
+        <ptm-bookmark
+          url="[[item.url]]"
+          fav-icon-url="{{item.favIconUrl}}"
+          bookmark-id="[[item.id]]"
+          tab-id="[[item.tabId]]"
+          site-title="[[item.title]]"
+          project-id="[[projectId]]"
+          on-toggle-bookmark="_toggleBookmark"></ptm-bookmark>
+      </template>
+    </iron-collapse>
   </template>
 </dom-module>
 

--- a/src/elements/ptm-session-list/ptm-session-list.html
+++ b/src/elements/ptm-session-list/ptm-session-list.html
@@ -25,6 +25,12 @@ Author: Eiji Kitamura (agektmr@gmail.com)
     *:focus {
       outline: none;
     }
+
+    /* Hide the topmost border and avoid double borders */
+    ptm-session[expanded]:first-of-type,
+    ptm-session[expanded] + ptm-session[expanded] {
+      border-top: none;
+    }
   </style>
   <template>
     <template id="repeat" is="dom-repeat" items="[[projects]]" filter="filter" sort="sort">

--- a/src/elements/ptm-session/ptm-session.html
+++ b/src/elements/ptm-session/ptm-session.html
@@ -19,7 +19,6 @@ Author: Eiji Kitamura (agektmr@gmail.com)
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../bower_components/paper-item/paper-item.html">
 <link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
-<link rel="import" href="../../bower_components/paper-material/paper-material.html">
 <link rel="import" href="../../bower_components/paper-ripple/paper-ripple.html">
 <link rel="import" href="../../bower_components/iron-collapse/iron-collapse.html">
 <link rel="import" href="../../bower_components/iron-selector/iron-selector.html">
@@ -36,8 +35,9 @@ Author: Eiji Kitamura (agektmr@gmail.com)
     *:focus {
       outline: none;
     }
-    paper-material[expanded] {
-      margin: 0 0 1em 0;
+    :host([expanded]) {
+      border-top: 1px solid var(--divider-color);
+      border-bottom: 1px solid var(--divider-color);
     }
     paper-item > *:not(:first-child):not(:last-child) {
       margin-right: 0 !important;
@@ -63,49 +63,47 @@ Author: Eiji Kitamura (agektmr@gmail.com)
     }
   </style>
   <template>
-    <paper-material elevation="[[_elevation]]" expanded$="[[expanded]]" animated>
-      <paper-item focused$="{{focused}}" tabindex="-1">
-        <paper-icon-button tabindex="-1" icon="[[_foldIcon]]" on-tap="toggle"></paper-icon-button>
-        <div class="title" on-tap="openProject" active$="[[_computeActive(winId)]]">
-          <!-- <paper-ripple></paper-ripple> -->
-          <span>[[projectTitle]]</span>
-        </div>
+    <paper-item focused$="{{focused}}" tabindex="-1">
+      <paper-icon-button tabindex="-1" icon="[[_foldIcon]]" on-tap="toggle"></paper-icon-button>
+      <div class="title" on-tap="openProject" active$="[[_computeActive(winId)]]">
+        <!-- <paper-ripple></paper-ripple> -->
+        <span>[[projectTitle]]</span>
+      </div>
+      <template is="dom-if" if="[[!_projectLinked]]" restamp>
+        <template is="dom-if" if="[[!expanded]]" restamp>
+          <paper-icon-button icon="notification:folder-special" on-tap="_onTapNewProject" tabindex="-1"></paper-icon-button>
+        </template>
+      </template>
+      <template is="dom-if" if="[[expanded]]" restamp>
         <template is="dom-if" if="[[!_projectLinked]]" restamp>
-          <template is="dom-if" if="[[!expanded]]" restamp>
-            <paper-icon-button icon="notification:folder-special" on-tap="_onTapNewProject" tabindex="-1"></paper-icon-button>
-          </template>
+          <paper-icon-button icon="icons:link" on-tap="_onTapLink" tabindex="-1"></paper-icon-button>
+          <paper-icon-button icon="notification:folder-special" on-tap="_onTapNewProject" tabindex="-1"></paper-icon-button>
         </template>
-        <template is="dom-if" if="[[expanded]]" restamp>
-          <template is="dom-if" if="[[!_projectLinked]]" restamp>
-            <paper-icon-button icon="icons:link" on-tap="_onTapLink" tabindex="-1"></paper-icon-button>
-            <paper-icon-button icon="notification:folder-special" on-tap="_onTapNewProject" tabindex="-1"></paper-icon-button>
-          </template>
-          <template is="dom-if" if="[[!_computeActive(winId)]]">
-            <paper-icon-button icon="icons:delete" on-tap="_onTapRemove" tabindex="-1"></paper-icon-button>
-          </template>
+        <template is="dom-if" if="[[!_computeActive(winId)]]">
+          <paper-icon-button icon="icons:delete" on-tap="_onTapRemove" tabindex="-1"></paper-icon-button>
         </template>
-      </paper-item>
-      <iron-collapse id="collapse" opened="[[expanded]]" tabindex="-1">
-        <div class="collapse-content">
-          <template is="dom-if" if="[[!fields.length]]">
-            <paper-item class="layout">
-              <paper-icon-button icon="icons:warning"></paper-icon-button>
-              <span class="title">{{_l10n('no_tabs')}}</span>
-            </paper-item>
-          </template>
-          <template id="repeat" is="dom-repeat" items="[[fields]]">
-            <ptm-bookmark
-              url="[[item.url]]"
-              fav-icon-url="{{item.favIconUrl}}"
-              bookmark-id="[[item.id]]"
-              tab-id="[[item.tabId]]"
-              site-title="[[item.title]]"
-              project-id="[[projectId]]"
-              on-toggle-bookmark="_toggleBookmark"></ptm-bookmark>
-          </template>
-        </div>
-      </iron-collapse>
-    </paper-material>
+      </template>
+    </paper-item>
+    <iron-collapse id="collapse" opened="[[expanded]]" tabindex="-1">
+      <div class="collapse-content">
+        <template is="dom-if" if="[[!fields.length]]">
+          <paper-item class="layout">
+            <paper-icon-button icon="icons:warning"></paper-icon-button>
+            <span class="title">{{_l10n('no_tabs')}}</span>
+          </paper-item>
+        </template>
+        <template id="repeat" is="dom-repeat" items="[[fields]]">
+          <ptm-bookmark
+            url="[[item.url]]"
+            fav-icon-url="{{item.favIconUrl}}"
+            bookmark-id="[[item.id]]"
+            tab-id="[[item.tabId]]"
+            site-title="[[item.title]]"
+            project-id="[[projectId]]"
+            on-toggle-bookmark="_toggleBookmark"></ptm-bookmark>
+        </template>
+      </div>
+    </iron-collapse>
   </template>
 </dom-module>
 


### PR DESCRIPTION
https://www.google.com/design/spec/components/lists.html

session/project lists are expandable lists, the material/paper formatting doesn't work right in this context.

Instead use the behaviour recommended for lists with expandable content:
- No elevation shadows or extra margins
- Style like a flat list of items
- When an item is expanded show a divider appears above and below the item

![screen shot 2016-02-25 at 6 19 38 pm](https://cloud.githubusercontent.com/assets/53399/13341529/6a40757e-dbee-11e5-9416-64ed61b37adf.png)
