### PR TITLE
Use the expand-* icons recommended by the material design guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 node_modules
 bower_components
 lib
+app

--- a/src/elements/ptm-project-behavior/ptm-project-behavior.html
+++ b/src/elements/ptm-project-behavior/ptm-project-behavior.html
@@ -102,7 +102,7 @@ var PtmProjectBehaviorImpl = {
     return expanded ? 2 : 0;
   },
   _computeFoldIcon: function(expanded) {
-    return expanded ? 'unfold-less' : 'unfold-more';
+    return expanded ? 'expand-more' : 'expand-less';
   },
   _computeProjectLinked: function(projectId) {
     return projectId * 1 > -1 ? true : false;


### PR DESCRIPTION
https://www.google.com/design/spec/components/lists-controls.html#lists-controls-types-of-list-controls

For lists, material design recommends expand-less and then expand-more when the item is expanded.

It recommends the icon to be on the right, but for now keeping it in the same location will have to do.

![screen shot 2016-02-25 at 7 01 23 pm](https://cloud.githubusercontent.com/assets/53399/13342038/98c6be9a-dbf2-11e5-8bbe-2836e8c0de2a.png)
